### PR TITLE
Add option to repeat short videos to show them for at least slideDuration

### DIFF
--- a/src/components/MediaPlayer.js
+++ b/src/components/MediaPlayer.js
@@ -176,6 +176,20 @@ const isVideo = url =>
 const isYouTube = url => url.includes("www.youtube-nocookie.com");
 
 class MediaPlayer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.playCount = 0;
+  }
+
+  repeatForDuration(evt) {
+    if (this.props.loopShortVideos && evt.target.duration * (++this.playCount) < this.props.duration) {
+      evt.target.play();
+    } else {
+      this.playCount = 0;
+      this.props.onEnded(evt);
+    }
+  }
+
   componentWillReceiveProps(nextProps) {
     if (isImage(nextProps.url)) {
       if (this.props.url !== nextProps.url || !this.timeout) {
@@ -199,7 +213,7 @@ class MediaPlayer extends React.Component {
           autoPlay
           muted={muted}
           onError={onEnded}
-          onEnded={onEnded}
+          onEnded={this.repeatForDuration.bind(this)}
         />
       );
     } else if (isImage(url)) {

--- a/src/configureStore.js
+++ b/src/configureStore.js
@@ -17,6 +17,7 @@ const defaultConfig = {
   pictures: true,
   videos: true,
   slideDuration: 10, // sec
+  loopShortVideos: false,
   enableVoice: true,
   enableMoans: true,
   videoMuted: false,

--- a/src/containers/Pages/ConfigPage.js
+++ b/src/containers/Pages/ConfigPage.js
@@ -487,6 +487,18 @@ class ConfigPage extends React.Component {
                   </FormControl>
                 </Grid>
                 <Grid item xs={12}>
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={store.config.loopShortVideos}
+                        onChange={this.handleCheckChange("loopShortVideos")}
+                        value="loopShortVideos"
+                      />
+                    }
+                    label="Loop Short Videos"
+                  />
+                </Grid>
+                <Grid item xs={12}>
                   <FormControl
                     component="fieldset"
                     required

--- a/src/containers/Pages/GamePage.js
+++ b/src/containers/Pages/GamePage.js
@@ -146,7 +146,7 @@ class GamePage extends React.Component {
 
     const {
       game: { orgasms, mediaPlayerUrl },
-      config: { maximumOrgasms, slideDuration, videoMuted }
+      config: { maximumOrgasms, slideDuration, loopShortVideos, videoMuted }
     } = this.props;
 
     return (
@@ -160,6 +160,7 @@ class GamePage extends React.Component {
               url={mediaPlayerUrl}
               onEnded={nextSlide}
               duration={slideDuration}
+              loopShortVideos={loopShortVideos}
               muted={videoMuted}
             />
           </React.Fragment>


### PR DESCRIPTION
Basically this: `while playCount * videoDuration < slideDuration: repeat video`

Disabled by default. Checkbox is right below the slide duration on the config page.

Unless something should be changed (not a react expert) I would consider this feature complete.


Is there a way to keep my fork in sync with this repo without creating merge commits? I have tried a github pull request and [this](https://help.github.com/articles/syncing-a-fork/). In both cases I ended up with a merge commit that puts my fork "ahead" of the main repo...